### PR TITLE
Update `n2vPrior` variable name to `carePrior`

### DIFF
--- a/CARE-Convallaria-2-Prediction.ipynb
+++ b/CARE-Convallaria-2-Prediction.ipynb
@@ -563,7 +563,7 @@
     "\n",
     "    print (\"image:\",index)\n",
     "    print (\"PSNR input\",PSNR(gt, im, rangePSNR))\n",
-    "    print (\"PSNR CARE\",n2vPrior) # Without info from masked pixel\n",
+    "    print (\"PSNR CARE\",carePrior) # Without info from masked pixel\n",
     "    print ('-----------------------------------')\n",
     "    \n",
     "    \n",
@@ -617,7 +617,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.1"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Hi Alex, 

Extremely minor comment!
`n2vPrior` variable is not initialized in the `CARE inference` notebook. It should be replaced by `carePrior` probably. 
Thank you!

